### PR TITLE
Fix homepage rendering and configuration for local development

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Button } from "@/ui/button";
 import { SiteHeader } from "@/components/site-header";
 import { SiteFooter } from "@/components/site-footer";
@@ -109,7 +111,13 @@ export default function HomePage() {
               animate={{ opacity: 1, scale: 1 }}
               transition={{ duration: 0.8, delay: 0.1 }}
             >
-              <Image src="https://images.unsplash.com/photo-1523365280197-f1783db9fe62" alt="Produk UMKM" fill className="object-cover" />
+              <Image
+                src="https://images.unsplash.com/photo-1523365280197-f1783db9fe62"
+                alt="Produk UMKM"
+                fill
+                unoptimized
+                className="object-cover"
+              />
             </motion.div>
           </div>
         </section>

--- a/lib/firebase/client.ts
+++ b/lib/firebase/client.ts
@@ -1,4 +1,4 @@
-import { getApps, initializeApp } from "firebase/app";
+import { getApps, initializeApp, type FirebaseOptions } from "firebase/app";
 import {
   browserLocalPersistence,
   connectAuthEmulator,
@@ -8,13 +8,25 @@ import {
 import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
 import { getStorage, connectStorageEmulator } from "firebase/storage";
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID
+const fallbackFirebaseConfig = {
+  apiKey: "demo-api-key",
+  authDomain: "localhost",
+  projectId: "demo-project",
+  storageBucket: "demo-project.appspot.com",
+  appId: "demo-app-id"
+} satisfies FirebaseOptions;
+
+const firebaseConfig: FirebaseOptions = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? fallbackFirebaseConfig.apiKey,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? fallbackFirebaseConfig.authDomain,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? fallbackFirebaseConfig.projectId,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? fallbackFirebaseConfig.storageBucket,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? fallbackFirebaseConfig.appId
 };
+
+if (process.env.NODE_ENV !== "production" && !process.env.NEXT_PUBLIC_FIREBASE_API_KEY) {
+  console.warn("Using fallback Firebase configuration. Provide NEXT_PUBLIC_FIREBASE_* env vars for full functionality.");
+}
 
 export function getClientApp() {
   if (!getApps().length) {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,10 @@ const nextConfig = {
       {
         protocol: "https",
         hostname: "storage.googleapis.com"
+      },
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- mark the landing page as a client component so Framer Motion renders correctly
- add a fallback Firebase configuration for development environments without env vars
- allow Unsplash images and disable optimization for the hero image to avoid remote fetch failures

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c60949c08327b171170cd1675740