### PR TITLE
Fix missing framer-motion manifest entries on auth pages

### DIFF
--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { AuthCard } from "@/components/auth-card";
 import { ResetPasswordForm } from "@/components/forms/reset-password-form";
 import { motion } from "framer-motion";

--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { AuthCard } from "@/components/auth-card";
 import { SignInForm } from "@/components/forms/signin-form";
 import { motion } from "framer-motion";

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { AuthCard } from "@/components/auth-card";
 import { SignUpForm } from "@/components/forms/signup-form";
 import { motion } from "framer-motion";


### PR DESCRIPTION
## Summary
- mark the auth route pages that use framer-motion as client components so motion elements are bundled correctly
- verified the landing page renders through a short automated browser session capture to ensure no manifest errors appear

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d6cb57d6648327b57624e13edff124