### PR TITLE
Fix auth navigation links and firebase initialization guard

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -17,7 +17,14 @@ import type { StudioJob } from "@/lib/types";
 
 export default function DashboardPage() {
   const [user, authLoading] = useAuthState(auth);
-  const { data: profile, displayName, createdAtDate, lastTrialAtDate, loading: profileLoading, error } = useUserProfile(user);
+  const {
+    data: profile,
+    displayName,
+    createdAtDate,
+    lastTrialAtDate,
+    loading: profileLoading,
+    error
+  } = useUserProfile(user ?? null);
 
   const { data: jobs, isLoading: jobsLoading } = useQuery({
     queryKey: ["jobs", { limit: 5 }],

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -14,7 +14,14 @@ import { formatDate, formatDateTime } from "@/lib/utils/format";
 
 export default function SettingsPage() {
   const [user, authLoading] = useAuthState(auth);
-  const { data: profile, displayName, createdAtDate, lastTrialAtDate, loading: profileLoading, error } = useUserProfile(user);
+  const {
+    data: profile,
+    displayName,
+    createdAtDate,
+    lastTrialAtDate,
+    loading: profileLoading,
+    error
+  } = useUserProfile(user ?? null);
 
   const handleResetPassword = async () => {
     const email = profile?.email ?? user?.email;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -209,9 +209,9 @@ export default function HomePage() {
       <SiteHeader />
       <main className="flex-1">
         <section className="relative overflow-hidden border-b border-brand/10 bg-[radial-gradient(circle_at_top,_rgba(37,99,235,0.35),_transparent_65%)] pb-24 pt-32">
-          <div className="absolute -left-1/4 top-0 h-72 w-72 rounded-full bg-brand/20 blur-3xl" />
-          <div className="absolute -right-1/4 bottom-0 h-80 w-80 rounded-full bg-blue-900/50 blur-3xl" />
-          <div className="container mx-auto flex flex-col gap-16 px-4 md:flex-row md:items-center">
+          <div className="pointer-events-none absolute -left-1/4 top-0 z-0 h-72 w-72 rounded-full bg-brand/20 blur-3xl" aria-hidden />
+          <div className="pointer-events-none absolute -right-1/4 bottom-0 z-0 h-80 w-80 rounded-full bg-blue-900/50 blur-3xl" aria-hidden />
+          <div className="container relative z-10 mx-auto flex flex-col gap-16 px-4 md:flex-row md:items-center">
             <div className="space-y-8 md:w-1/2">
               <motion.span
                 className="inline-flex items-center gap-2 rounded-full border border-brand/30 bg-brand/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-brand-foreground"

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+import { Avatar, AvatarFallback } from "@/ui/avatar";
+import { Button } from "@/ui/button";
+import { Separator } from "@/ui/separator";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/ui/sheet";
+
+type NavItem = { href: string; label: string };
+
+type GuestMobileNavProps = {
+  navItems: NavItem[];
+};
+
+export function GuestMobileNav({ navItems }: GuestMobileNavProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          className="relative h-10 w-10 rounded-full p-0 md:hidden"
+          aria-label="Buka menu navigasi"
+        >
+          <Avatar className="h-9 w-9">
+            <AvatarFallback className="text-[0.65rem] font-semibold uppercase">UM</AvatarFallback>
+          </Avatar>
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="left" className="flex h-full w-72 flex-col overflow-y-auto px-0 py-0">
+        <SheetHeader className="border-b px-6 py-4 text-left">
+          <SheetTitle className="text-base font-semibold">UMKM MINI STUDIO</SheetTitle>
+          <p className="text-xs text-muted-foreground">Masuk untuk mengakses dashboard & fitur kreatif.</p>
+        </SheetHeader>
+        <nav className="flex flex-1 flex-col gap-1 px-2 py-4">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-foreground transition hover:bg-accent hover:text-accent-foreground"
+              onClick={() => setOpen(false)}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <Separator className="mx-4" />
+        <div className="grid gap-2 px-4 py-4">
+          <Button asChild size="sm" onClick={() => setOpen(false)}>
+            <Link href="/signin">Sign in</Link>
+          </Button>
+          <Button asChild size="sm" variant="outline" onClick={() => setOpen(false)}>
+            <Link href="/signup">Sign up</Link>
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+

--- a/components/protected-shell.tsx
+++ b/components/protected-shell.tsx
@@ -14,7 +14,12 @@ import { useUserProfile } from "@/lib/hooks/use-user-profile";
 export function ProtectedShell({ children }: { children: React.ReactNode }) {
   const [user, loading] = useAuthState(auth);
   const router = useRouter();
-  const { data: profile, displayName, loading: profileLoading, error: profileError } = useUserProfile(user);
+  const {
+    data: profile,
+    displayName,
+    loading: profileLoading,
+    error: profileError
+  } = useUserProfile(user ?? null);
   const initRef = useRef(false);
 
   useEffect(() => {

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -8,6 +8,7 @@ import { useMemo } from "react";
 import { UserNav } from "./user-nav";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "@/lib/firebase";
+import { GuestMobileNav } from "./mobile-nav";
 
 export function SiteHeader() {
   const t = useI18n();
@@ -23,7 +24,7 @@ export function SiteHeader() {
   );
 
   return (
-    <header className="sticky top-0 z-30 w-full border-b border-brand/10 bg-background/70 shadow-[0_12px_40px_-18px_rgba(37,99,235,0.65)] backdrop-blur">
+    <header className="sticky top-0 z-50 w-full border-b border-brand/10 bg-background/70 shadow-[0_12px_40px_-18px_rgba(37,99,235,0.65)] backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
         <Link href="/" className="flex items-center space-x-6 font-semibold text-foreground">
           <span className="block text-base sm:hidden">UMKM MINI STUDIO</span>
@@ -47,6 +48,7 @@ export function SiteHeader() {
             <UserNav user={user} />
           ) : (
             <>
+              <GuestMobileNav navItems={navItems} />
               <Button asChild variant="ghost" className="hidden sm:inline-flex">
                 <Link href="/signin">{t["nav.signIn"]}</Link>
               </Button>

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { getApp, getApps, initializeApp } from "firebase/app";
+import { getApp, getApps, initializeApp, type FirebaseApp, type FirebaseOptions } from "firebase/app";
 import {
   browserLocalPersistence,
   connectAuthEmulator,
@@ -11,15 +11,54 @@ import {
 import { connectFirestoreEmulator, getFirestore } from "firebase/firestore";
 import { connectStorageEmulator, getStorage } from "firebase/storage";
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!
+const FALLBACK_CONFIG: FirebaseOptions = {
+  apiKey: "AIzaFakeKeyForLocalDevOnly0000000000",
+  authDomain: "localhost",
+  projectId: "umkm-mini-studio-demo",
+  storageBucket: "umkm-mini-studio-demo.appspot.com",
+  appId: "1:000000000000:web:localdevfallback"
 };
 
-const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+type GlobalWithFirebaseWarning = typeof globalThis & {
+  __umkmFirebaseConfigWarned__?: boolean;
+};
+
+function resolveFirebaseConfig(): FirebaseOptions {
+  const configEntries = {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID
+  } as const;
+
+  const missingKeys = Object.entries(configEntries)
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missingKeys.length > 0) {
+    const globalWithWarning = globalThis as GlobalWithFirebaseWarning;
+    if (!globalWithWarning.__umkmFirebaseConfigWarned__) {
+      console.warn(
+        `Firebase client configuration missing environment variables: ${missingKeys.join(", ")}. Using fallback config for UI-only mode.`
+      );
+      globalWithWarning.__umkmFirebaseConfigWarned__ = true;
+    }
+    return FALLBACK_CONFIG;
+  }
+
+  return {
+    apiKey: configEntries.apiKey!,
+    authDomain: configEntries.authDomain!,
+    projectId: configEntries.projectId!,
+    storageBucket: configEntries.storageBucket!,
+    appId: configEntries.appId!
+  } satisfies FirebaseOptions;
+}
+
+const firebaseConfig = resolveFirebaseConfig();
+
+const app: FirebaseApp = getApps().length ? getApp() : initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
 export const db = getFirestore(app);

--- a/tests/auth-navigation.spec.ts
+++ b/tests/auth-navigation.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test.use({ storageState: undefined });
+
+test("landing sign in button opens /signin", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("link", { name: /sign in/i }).click();
+  await expect(page).toHaveURL(/\/signin$/);
+});
+
+test("landing sign up button opens /signup", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("link", { name: /sign up/i }).click();
+  await expect(page).toHaveURL(/\/signup$/);
+});
+
+test("mobile navigation sheet exposes auth links", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+
+  const trigger = page.getByRole("button", { name: "Buka menu navigasi" });
+  await trigger.click();
+
+  const signInLink = page.getByRole("link", { name: /sign in/i });
+  await expect(signInLink).toBeVisible();
+  await signInLink.click();
+
+  await expect(page).toHaveURL(/\/signin$/);
+});
+

--- a/ui/sheet.tsx
+++ b/ui/sheet.tsx
@@ -9,8 +9,8 @@ const Sheet = SheetPrimitive.Root;
 const SheetTrigger = SheetPrimitive.Trigger;
 const SheetClose = SheetPrimitive.Close;
 
-const SheetPortal = ({ className, ...props }: SheetPrimitive.DialogPortalProps) => (
-  <SheetPrimitive.Portal className={cn(className)} {...props} />
+const SheetPortal = (props: SheetPrimitive.DialogPortalProps) => (
+  <SheetPrimitive.Portal {...props} />
 );
 SheetPortal.displayName = SheetPrimitive.Portal.displayName;
 


### PR DESCRIPTION
## Summary
- add a guest mobile sheet trigger and adjust the site header layering so auth links are clickable on all viewports
- guard Firebase client initialization with a fallback config and warn when required env vars are missing instead of crashing
- document the fixes, add a Playwright navigation smoke test, and update sheet + profile hooks to handle optional auth state

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d78825aed48327929d583dfdc571d0