### PR TITLE
chore: harden playwright auth setup and ci

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,38 @@
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+      CODEGEN_EMAIL: ${{ secrets.CODEGEN_EMAIL }}
+      CODEGEN_PASSWORD: ${{ secrets.CODEGEN_PASSWORD }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile=false
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: pnpm exec playwright test

--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ pnpm test
 pnpm lint
 ```
 
+#### End-to-end (Playwright)
+
+Playwright otomatis melakukan build dan menjalankan server Next.js melalui konfigurasi `webServer`, jadi tidak perlu menyalakan server manual.
+
+```bash
+# Menjalankan seluruh e2e test tanpa login (otomatis skip yang butuh kredensial)
+pnpm exec playwright test
+
+# Opsional: verifikasi build Next.js sebelum e2e
+pnpm build
+```
+
+Untuk menjalankan skenario yang membutuhkan login, set variabel lingkungan berikut sebelum memanggil Playwright:
+
+```bash
+export NEXT_PUBLIC_FIREBASE_API_KEY="<api-key>"
+export CODEGEN_EMAIL="<bot-email>"
+export CODEGEN_PASSWORD="<bot-password>"
+
+pnpm exec playwright test
+```
+
+Global setup akan melakukan login headless (REST `signInWithPassword` → `POST /api/auth/session-login`) dan menyimpan cookie ke `storageState.json`. Jika variabel belum di-set, file kosong dibuat sehingga test yang diberi tanda "butuh login" otomatis di-skip.
+
+#### CI
+
+Contoh workflow GitHub Actions tersedia di `.github/workflows/e2e.yml`. Simpan `NEXT_PUBLIC_FIREBASE_API_KEY`, `CODEGEN_EMAIL`, dan `CODEGEN_PASSWORD` sebagai repository secrets agar skenario login berjalan di pipeline.
+
 ## Headless Login (Cara #2)
 
 Gunakan alur login headless dengan session cookie HTTP-only untuk otomatisasi (CI, Playwright, bot).

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,22 @@
 import { defineConfig } from "@playwright/test";
 
+const PORT = Number(process.env.PORT ?? 3000);
+const HOST = process.env.HOST ?? "127.0.0.1";
+const baseURL = process.env.APP_URL || `http://${HOST}:${PORT}`;
+
 export default defineConfig({
   testDir: "./tests",
+  testMatch: "**/*.spec.ts",
   timeout: 30_000,
   use: {
-    baseURL: process.env.APP_URL || "http://localhost:3000",
+    baseURL,
     storageState: "storageState.json"
   },
-  globalSetup: "./tests/global-setup.ts"
+  globalSetup: "./tests/global-setup.ts",
+  webServer: {
+    command: "pnpm build && pnpm start",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000
+  }
 });

--- a/tests/auth-navigation.spec.ts
+++ b/tests/auth-navigation.spec.ts
@@ -2,29 +2,45 @@ import { test, expect } from "@playwright/test";
 
 test.use({ storageState: undefined });
 
-test("landing sign in button opens /signin", async ({ page }) => {
-  await page.goto("/");
-  await page.getByRole("link", { name: /sign in/i }).click();
-  await expect(page).toHaveURL(/\/signin$/);
+const loginUnavailable = process.env.PLAYWRIGHT_AUTH_AVAILABLE !== "true";
+const signInPattern = /sign\s*in|masuk/i;
+const signUpPattern = /sign\s*up|daftar/i;
+
+test.describe("Public landing navigation", () => {
+  test("landing sign in button opens /signin", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: signInPattern }).first().click();
+    await expect(page).toHaveURL(/\/signin$/);
+  });
+
+  test("landing sign up button opens /signup", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: signUpPattern }).first().click();
+    await expect(page).toHaveURL(/\/signup$/);
+  });
+
+  test("mobile navigation sheet exposes auth links", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+
+    const trigger = page.getByRole("button", { name: "Buka menu navigasi" });
+    await trigger.click();
+
+    const signInLink = page.getByRole("link", { name: signInPattern }).first();
+    await expect(signInLink).toBeVisible();
+    await signInLink.click();
+
+    await expect(page).toHaveURL(/\/signin$/);
+  });
 });
 
-test("landing sign up button opens /signup", async ({ page }) => {
-  await page.goto("/");
-  await page.getByRole("link", { name: /sign up/i }).click();
-  await expect(page).toHaveURL(/\/signup$/);
+test.describe("Authenticated navigation", () => {
+  test.skip(loginUnavailable, "Login credentials not configured. Skipping authenticated navigation checks.");
+  test.use({ storageState: "storageState.json" });
+
+  test("dashboard stays accessible", async ({ page }) => {
+    const response = await page.goto("/dashboard");
+    expect(response?.status()).toBeLessThan(400);
+    await expect(page).toHaveURL(/\/dashboard$/);
+  });
 });
-
-test("mobile navigation sheet exposes auth links", async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 844 });
-  await page.goto("/");
-
-  const trigger = page.getByRole("button", { name: "Buka menu navigasi" });
-  await trigger.click();
-
-  const signInLink = page.getByRole("link", { name: /sign in/i });
-  await expect(signInLink).toBeVisible();
-  await signInLink.click();
-
-  await expect(page).toHaveURL(/\/signin$/);
-});
-

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from "@playwright/test";
 
-test("dashboard loads (logged-in)", async ({ page }) => {
-  await page.goto("/dashboard");
-  await expect(page.getByText(/Credits/i)).toBeVisible();
+const loginUnavailable = process.env.PLAYWRIGHT_AUTH_AVAILABLE !== "true";
+
+test.describe("Authenticated dashboard", () => {
+  test.skip(loginUnavailable, "Login credentials not configured. Skipping authenticated smoke test.");
+  test.use({ storageState: "storageState.json" });
+
+  test("dashboard loads (logged-in)", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page.getByText(/Credits/i)).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- configure Playwright to build/start Next.js automatically, limit matches to e2e specs, and add CI workflow
- rewrite global setup to tolerate missing Firebase credentials while performing REST login when available
- update e2e specs to gate authenticated checks and document local/CI usage in the README

## Testing
- pnpm build
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d790146de88327bb4e224b3593a8aa